### PR TITLE
Adapt to OpenWrt renaming hostpapd.wlan* to hostapd.phy*-ap*

### DIFF
--- a/bin
+++ b/bin
@@ -13,14 +13,14 @@ function _do_updates() {
 	# Discover neighbors and self
 	ubus call umdns update
 	sleep 5
-	for wifi_iface in $(ubus list hostapd.wlan* | awk -F. '{ print $2; }'); do
+	for wifi_iface in $(ubus list hostapd.* | awk -F. '{ print $2; }'); do
 		net_ssid=$(iwinfo ${wifi_iface} info | head -n1 | cut -d\" -f2)
 		[ -z "${net_ssid}" ] && logger -t "rrm_nr" -p daemon.error "${wifi_iface}: does not have ssid according to iwinfo." && continue
 		
 		# Discover other nodes
 		rrm_nr_lists=""
 
-		for other_iface in $(ubus list hostapd.wlan* | awk -F. '{ print $2; }'); do
+		for other_iface in $(ubus list hostapd.* | awk -F. '{ print $2; }'); do
 			[ ${wifi_iface} = ${other_iface} ] && continue
 
 			[ ${net_ssid} = $(iwinfo ${other_iface} info | head -n1 | cut -d\" -f2) ] && rrm_nr_lists="${rrm_nr_lists}"$'\n'"$(/bin/ubus call hostapd.${other_iface} rrm_nr_get_own | /usr/bin/jsonfilter -e '$.value')"

--- a/initscript
+++ b/initscript
@@ -13,7 +13,7 @@ start_service() {
 
 	local rrm_own
 	#todo skip if nr is disabled for interface, skip disabled interface etc.
-	#while [ "$(ubus list hostapd.wlan* | wc -l)" != "$(grep 'wifi-iface' /etc/config/wireless | wc -l)" ]; do
+	#while [ "$(ubus list hostapd.* | wc -l)" != "$(grep 'wifi-iface' /etc/config/wireless | wc -l)" ]; do
 	#	logger -t "${NAME}" -pdaemon.info "Waiting for all interfaces to initialize"
 	#	sleep 30
 	#done
@@ -21,7 +21,7 @@ start_service() {
 	OIFS=$IFS
 	IFS=$'\x0a'
 
-	for value in $(ubus list hostapd.wlan*); do
+	for value in $(ubus list hostapd.*); do
 		rrm_own="${rrm_own}|$(/bin/ubus call ${value} rrm_nr_get_own | /usr/bin/jsonfilter -e '$.value')"
 	done
 


### PR DESCRIPTION
Make the mask `hostpapd.wlan*` less restrictive `hostpapd.*` to cater for OpenWrt's renaming `hostpapd.wlan*` to `hostapd.phy*-ap*`.

Aims to addresses issue #3. 