### PR TITLE
Switch to TXT record per neighbor

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,5 +19,4 @@
 
 ## Known issues
 
-- SSIDs with '|' character are not supported at the moment
 - With large number of APs (>20) the full umdns update takes a few interations/minutes

--- a/bin
+++ b/bin
@@ -5,7 +5,7 @@
 NAME=rrm_nr
 
 # We wrap everything into this function to allow GC by ash, esp. for low-mem devices
-function _do_updates() {
+_do_updates() {
 	local rrm_nr_lists
 
 	OIFS=$IFS
@@ -16,7 +16,7 @@ function _do_updates() {
 	for wifi_iface in $(ubus list hostapd.* | awk -F. '{ print $2; }'); do
 		net_ssid=$(iwinfo ${wifi_iface} info | head -n1 | cut -d\" -f2)
 		[ -z "${net_ssid}" ] && logger -t "rrm_nr" -p daemon.error "${wifi_iface}: does not have ssid according to iwinfo." && continue
-		
+
 		# Discover other nodes
 		rrm_nr_lists=""
 
@@ -26,9 +26,8 @@ function _do_updates() {
 			[ ${net_ssid} = $(iwinfo ${other_iface} info | head -n1 | cut -d\" -f2) ] && rrm_nr_lists="${rrm_nr_lists}"$'\n'"$(/bin/ubus call hostapd.${other_iface} rrm_nr_get_own | /usr/bin/jsonfilter -e '$.value')"
 		done
 
-
 		# Sort at the end stabilizes the result, so we can compare it across runs
-		for discovered_node in $(ubus call umdns browse | jsonfilter -e '@["_rrm_nr._udp"][*].txt' | tr '|' '\n' | grep "\"${net_ssid}\""); do #TODO replace tr with sed "s= ]|[ = ]\n[ ="
+		for discovered_node in $(ubus call umdns browse '{ "service": "_rrm_nr._udp", "array": true }' | jsonfilter -e '@["_rrm_nr._udp"][*].txt[*]' | grep "\"${net_ssid}\"" | sed "s/${net_ssid}=//g"); do
 			rrm_nr_lists="${rrm_nr_lists}"$'\n'"${discovered_node}"
 		done
 

--- a/initscript
+++ b/initscript
@@ -22,24 +22,31 @@ start_service() {
 	IFS=$'\x0a'
 
 	for value in $(ubus list hostapd.*); do
-		rrm_own="${rrm_own}|$(/bin/ubus call ${value} rrm_nr_get_own | /usr/bin/jsonfilter -e '$.value')"
+		curr_value=$(/bin/ubus call "${value}" rrm_nr_get_own | /usr/bin/jsonfilter -e '$.value')
+		ssid=$(echo "$curr_value" | awk -F, '{ print $2; }' | sed 's/^ *"//;s/" *$//')
+		# Using + as the delimiter instead of |. Because + is an invalid character to use in SSID naming,
+		# this removes the known issue where | could not be used in the SSID name.
+		rrm_own="${rrm_own}+${ssid}=${curr_value}"
 	done
+
+	rrm_own="${rrm_own#*+}"
+	IFS='+'
+	set -- $rrm_own
 
 	IFS=$OIFS
 
 	procd_open_instance
 	procd_set_param command /bin/sh "/usr/bin/rrm_nr"
 	#https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml?search=5247
-	procd_add_mdns "rrm_nr" "udp" "5247" "${rrm_own:1}" 
+	procd_add_mdns "rrm_nr" "udp" "5247" "$@"
 	procd_close_instance
 }
 
-boot(){
+boot() {
 	sleep 30
 	start
 }
 
-service_triggers()
-{
+service_triggers() {
 	procd_add_reload_trigger wireless
 }

--- a/umdns_repo.patch
+++ b/umdns_repo.patch
@@ -1,0 +1,17 @@
+diff --git a/package/network/services/umdns/Makefile b/package/network/services/umdns/Makefile
+index a25233ad5a..3f3c64a240 100644
+--- a/package/network/services/umdns/Makefile
++++ b/package/network/services/umdns/Makefile
+@@ -12,9 +12,9 @@ PKG_RELEASE:=$(AUTORELEASE)
+
+ PKG_SOURCE_URL=$(PROJECT_GIT)/project/mdnsd.git
+ PKG_SOURCE_PROTO:=git
+-PKG_SOURCE_DATE:=2021-05-13
+-PKG_SOURCE_VERSION:=b777a0b53f7d89ab2a60e3eed7d98036806da9a4
+-PKG_MIRROR_HASH:=54992acf7edd32610de7bcb0ea7c58b20f69bf1ac20be69e76abcff41f25e775
++PKG_SOURCE_DATE:=2023-01-16
++PKG_SOURCE_VERSION:=65b3308d13de7d7975444d34389651612e2a4d38
++PKG_MIRROR_HASH:=945fdf51a299b68982aab74e8fba5614f2553a7b4c49a3a53b3093ea8aac0279
+
+ PKG_MAINTAINER:=John Crispin <john@phrozen.org>
+ PKG_LICENSE:=LGPL-2.1


### PR DESCRIPTION
While testing this, I found that due to the number of SSIDs in my environment, I was exceeding the 255 char limit for a single TXT record. Therefore, my neighbor TXT record was being truncated and failed to work properly.

This PR is a tested conversion to creating an array of TXT records whereby neighbors now have a 1:1 TXT record. Each TXT record format is:
`<SSID>=[ "<MAC>", "<SSID>", "<NR Information Element>" ]`

For example (w/sensitive bits redacted):

```json
root@AP:~# ubus call umdns browse '{ "service": "_rrm_nr._udp", "array": true }'
{
	"_rrm_nr._udp": {
		"AP-LivingRoom": {
			"iface": "br-lan.1",
			"ipv4": [
				"192.168.xx.xx"
			],
			"ipv6": [
				"fe80::ea9f:80ff:fef0:6886",
				"2600:1700:994::x"
			],
			"port": 5247,
			"txt": [
				"Z9_example=[ \"e8:9f:80:xx:yy:zz\", \"Z9_example\", \"e89f80xxyyzze.......................\" ]",
				"Z99_example=[ \"ea:9f:80:xx:yy:zz\", \"Z99_example\", \"ea9f80xxyyzze.......................\" ]",
				"Z7_3_example=[ \"ee:9f:80:xx:yy:zz\", \"Z7_3_example\", \"ee9f80xxyyzze.......................\" ]",
				"Z9_3_example=[ \"e2:9f:80:xx:yy:zz\", \"Z9_3_example\", \"e29f80xxyyzze.......................\" ]",
				"Z9_example=[ \"e8:9f:80:xx:yy:zz\", \"Z9_example\", \"e89f80xxyyzze.......................\" ]",
				"Z7_3_example=[ \"ea:9f:80:xx:yy:zz\", \"Z7_3_example\", \"ea9f80xxyyzze.......................\" ]",
				"Z9_3_example=[ \"ee:9f:80:xx:yy:zz\", \"Z9_3_example\", \"ee9f80xxyyzze.......................\" ]"
			]
		},
		"AP-Office": {
			"iface": "br-lan.1",
			"ipv4": [
				"192.168.xx.xx"
			],
			"ipv6": [
				"2600:1700:994::x",
				"fe80::ea9f:80ff:fe50:5ca8"
			],
			"port": 5247,
			"txt": [
				"Z7_example=[ \"e8:9f:80:xx:yy:zz\", \"Z7_example\", \"e89f80xxyyzze.......................\" ]",
				"Z9_example=[ \"ea:9f:80:xx:yy:zz\", \"Z9_example\", \"ea9f80xxyyzze.......................\" ]",
				"Z99_example=[ \"ee:9f:80:xx:yy:zz\", \"Z99_example\", \"ee9f80xxyyzze.......................\" ]",
				"Z9_3_example=[ \"e2:9f:80:xx:yy:zz\", \"Z9_3_example\", \"e29f80xxyyzze.......................\" ]",
				"Z7_example=[ \"e8:9f:80:xx:yy:zz\", \"Z7_example\", \"e89f80xxyyzze.......................\" ]",
				"Z9_example=[ \"ea:9f:80:xx:yy:zz\", \"Z9_example\", \"ea9f80xxyyzze.......................\" ]",
				"Z9_3_example=[ \"ee:9f:80:xx:yy:zz\", \"Z9_3_example\", \"ee9f80xxyyzze.......................\" ]"
			]
		}
	}
}
```

Unfortunately, the `package/network/services/umdns/Makefile` in snapshot (and likely release branches) is not synced to the latest umDNS commit, which includes a number of improvements including the ability to pass a service name by which to filter the `browse` call, as well as a boolean flag to return the browse result as an array.

For this reason, I am including a patch file that will update the umDNS makefile to pull these latest updates. I realize this is not an ideal situation, but perhaps John Crispin could be convinced to push an official update to the umDNS makefile.