### PR TITLE
Draft: Refactor to implement hash map functionality

### DIFF
--- a/bin
+++ b/bin
@@ -4,26 +4,91 @@
 
 NAME=rrm_nr
 
+# Make sure we clean up our tmp dir on probable exit signals
+cleanup() {
+	rc=$?
+	rm -rf "$hashmap"
+	logger -t "rrm_nr" -p daemon.info "Removed hash map directory: $hashmap"
+	exit $rc
+}
+trap cleanup EXIT INT HUP TERM QUIT
+
+# Hash Map concept adopted from here:
+# https://www.baeldung.com/linux/posix-shell-array#associative-arrays--hash-maps
+
+# Function to create a new tmp dir for our hashmap
+hm_create() {
+	mktemp -d
+}
+
+# Function to create the hash value (checksum)
+hm_hash() {
+	echo "$1" | md5sum -
+}
+
+# Argument 1: Hash Table
+# Argument 2: Key
+# Argument 3: Value
+hm_put() {
+	echo "$3" > "$1/$(hm_hash "$2")"
+}
+
+# Argument 1: Hash Table
+# Argument 2: Key
+hm_delete() {
+	rm -f "$1/$(hm_hash "$2")"
+}
+
+# Argument 1: Hash Table
+# Argument 2: Key
+hm_get() {
+	cat "$1/$(hm_hash "$2")"
+}
+
+first_run_complete=0
+hashmap="$(hm_create)"
+
 # We wrap everything into this function to allow GC by ash, esp. for low-mem devices
-_do_updates() {
+do_updates() {
+	# If the first run, set the hostapd device-->SSID mapping so we can avoid this expensive
+	# process on future iterations
+	if [ $first_run_complete -eq 0 ]; then
+		for wifi_iface in $(ubus list hostapd.* | awk -F. '{ print $2; }'); do
+			net_ssid=$(iwinfo ${wifi_iface} info | head -n1 | cut -d\" -f2)
+			[ -z "${net_ssid}" ] && logger -t "rrm_nr" -p daemon.error "${wifi_iface}: does not have ssid according to iwinfo." && continue
+
+			# Store the mapping of hostapd-->SSID for faster lookup
+			hm_put "$hashmap" "$wifi_iface" "$net_ssid"
+		done
+
+		first_run_complete=1
+		logger -t "rrm_nr" -p daemon.info "Created initial hash map directory: $hashmap"
+	fi
+
 	local rrm_nr_lists
 
 	OIFS=$IFS
 	IFS=$'\n'
+
 	# Discover neighbors and self
 	ubus call umdns update
 	sleep 5
-	for wifi_iface in $(ubus list hostapd.* | awk -F. '{ print $2; }'); do
-		net_ssid=$(iwinfo ${wifi_iface} info | head -n1 | cut -d\" -f2)
-		[ -z "${net_ssid}" ] && logger -t "rrm_nr" -p daemon.error "${wifi_iface}: does not have ssid according to iwinfo." && continue
+
+	# Do this lookup as few times as possible for each update iteration
+	hostapd_members=$(ubus list hostapd.* | awk -F. '{ print $2; }')
+
+	for wifi_iface in $hostapd_members; do
+		net_ssid=$(hm_get "$hashmap" "$wifi_iface")
 
 		# Discover other nodes
 		rrm_nr_lists=""
 
-		for other_iface in $(ubus list hostapd.* | awk -F. '{ print $2; }'); do
-			[ ${wifi_iface} = ${other_iface} ] && continue
+		for other_iface in $hostapd_members; do
+			[ "${wifi_iface}" = "${other_iface}" ] && continue
 
-			[ ${net_ssid} = $(iwinfo ${other_iface} info | head -n1 | cut -d\" -f2) ] && rrm_nr_lists="${rrm_nr_lists}"$'\n'"$(/bin/ubus call hostapd.${other_iface} rrm_nr_get_own | /usr/bin/jsonfilter -e '$.value')"
+			if [ "${net_ssid}" = "$(hm_get "$hashmap" "$other_iface")" ]; then
+				rrm_nr_lists="${rrm_nr_lists}"$'\n'"$(/bin/ubus call hostapd.${other_iface} rrm_nr_get_own | /usr/bin/jsonfilter -e '$.value')"
+			fi
 		done
 
 		# Sort at the end stabilizes the result, so we can compare it across runs
@@ -52,7 +117,7 @@ _do_updates() {
 }
 
 while true; do
-	_do_updates
+	do_updates
 
 	sleep 60
 done

--- a/bin
+++ b/bin
@@ -116,10 +116,27 @@ do_updates() {
 	IFS=$OIFS
 }
 
-while true; do
-	do_updates
+# This is an alternate approach to the original "sleep 60" in the while loop below.
+# The issue with "sleep 60" is that the rrm_nr service will not exit cleanly because
+# by default it only waits up to 5 seconds for this script to exit. But because the while
+# loop is sleeping, it fails to clean up the tmp directory (for hash map) because procd
+# sends a SIGKILL which cannot be trapped.
 
-	sleep 60
+# Set the delay_counter to 20 initially so we immediately execute do_updates upon entering
+# the while loop. Then subsequently set the counter back to 0 and begin incrementing every
+# 3 seconds until we reach 20 iterations again (=60 seconds between do_updates calls).
+# In this way, procd can actually signal a clean exit since this will become responsive again
+# every 3 seconds now.
+delay_counter=20
+while true; do
+	if [ $delay_counter -eq 20 ]; then
+		do_updates
+		delay_counter=0
+	else
+		: $((delay_counter+=1))
+	fi
+
+	sleep 3
 done
 
 exit 0

--- a/bin
+++ b/bin
@@ -27,7 +27,7 @@ _do_updates() {
 		done
 
 		# Sort at the end stabilizes the result, so we can compare it across runs
-		for discovered_node in $(ubus call umdns browse '{ "service": "_rrm_nr._udp", "array": true }' | jsonfilter -e '@["_rrm_nr._udp"][*].txt[*]' | grep "\"${net_ssid}\"" | sed "s/${net_ssid}=//g"); do
+		for discovered_node in $(ubus call umdns browse '{ "service": "_rrm_nr._udp", "array": true }' | jsonfilter -e '@["_rrm_nr._udp"][*].txt[*]' | grep "\"${net_ssid}\"" | sed -E "s/SSID\d+=//g"); do
 			rrm_nr_lists="${rrm_nr_lists}"$'\n'"${discovered_node}"
 		done
 

--- a/bin
+++ b/bin
@@ -51,10 +51,27 @@ _do_updates() {
 	IFS=$OIFS
 }
 
-while true; do
-	_do_updates
+# This is an alternate approach to the original "sleep 60" in the while loop below.
+# The issue with "sleep 60" is that the rrm_nr service will not exit cleanly because
+# by default it only waits up to 5 seconds for this script to exit. But because the while
+# loop is sleeping, it fails to exit cleanly because procd sends a SIGKILL which cannot be
+# trapped.
 
-	sleep 60
+# Set the delay_counter to 20 initially so we immediately execute do_updates upon entering
+# the while loop. Then subsequently set the counter back to 0 and begin incrementing every
+# 3 seconds until we reach 20 iterations again (=60 seconds between do_updates calls).
+# In this way, procd can actually signal a clean exit since this will become responsive again
+# every 3 seconds now.
+delay_counter=20
+while true; do
+	if [ $delay_counter -eq 20 ]; then
+		_do_updates
+		delay_counter=0
+	else
+		delay_counter=$((delay_counter + 1))
+	fi
+
+	sleep 3
 done
 
 exit 0

--- a/initscript
+++ b/initscript
@@ -36,7 +36,7 @@ start_service() {
 	IFS=$OIFS
 
 	procd_open_instance
-	procd_set_param term_timeout 60
+	procd_set_param term_timeout 5
 	procd_set_param command /bin/sh "/usr/bin/rrm_nr"
 	#https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml?search=5247
 	procd_add_mdns "rrm_nr" "udp" "5247" "$@"

--- a/initscript
+++ b/initscript
@@ -21,12 +21,14 @@ start_service() {
 	OIFS=$IFS
 	IFS=$'\x0a'
 
+	local ssid_count=1
 	for value in $(ubus list hostapd.*); do
 		curr_value=$(/bin/ubus call "${value}" rrm_nr_get_own | /usr/bin/jsonfilter -e '$.value')
 		ssid=$(echo "$curr_value" | awk -F, '{ print $2; }' | sed 's/^ *"//;s/" *$//')
 		# Using + as the delimiter instead of |. Because + is an invalid character to use in SSID naming,
 		# this removes the known issue where | could not be used in the SSID name.
-		rrm_own="${rrm_own}+${ssid}=${curr_value}"
+		rrm_own="${rrm_own}+SSID${ssid_count}=${curr_value}"
+		ssid_count=$((ssid_count + 1))
 	done
 
 	rrm_own="${rrm_own#*+}"

--- a/initscript
+++ b/initscript
@@ -24,7 +24,6 @@ start_service() {
 	local ssid_count=1
 	for value in $(ubus list hostapd.*); do
 		curr_value=$(/bin/ubus call "${value}" rrm_nr_get_own | /usr/bin/jsonfilter -e '$.value')
-		ssid=$(echo "$curr_value" | awk -F, '{ print $2; }' | sed 's/^ *"//;s/" *$//')
 		# Using + as the delimiter instead of |. Because + is an invalid character to use in SSID naming,
 		# this removes the known issue where | could not be used in the SSID name.
 		rrm_own="${rrm_own}+SSID${ssid_count}=${curr_value}"

--- a/initscript
+++ b/initscript
@@ -36,6 +36,7 @@ start_service() {
 	IFS=$OIFS
 
 	procd_open_instance
+	procd_set_param term_timeout 60
 	procd_set_param command /bin/sh "/usr/bin/rrm_nr"
 	#https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml?search=5247
 	procd_add_mdns "rrm_nr" "udp" "5247" "$@"
@@ -48,5 +49,5 @@ boot() {
 }
 
 service_triggers() {
-	procd_add_reload_trigger wireless
+	procd_add_reload_trigger "network" "wireless"
 }


### PR DESCRIPTION
This is a proposed refactor that makes use of a hash map that gets stored in a new directory in `/tmp`. As `/tmp` resides on tmpfs (volatile memory), this should not be a costly write for limited write storage devices.

The goal of the hash map is to do a one-time mapping of hostapd devices --> SSID names. In this way, the script can lookup against that hash map instead of having to call expensive `ubus list hostapd.*` and `iwinfo <iface> info` each `do_updates` iteration.

Also added a trigger for `network` config file changes to cause a service restart.