### PR TITLE
remove extra characters from md5sum output

### DIFF
--- a/bin
+++ b/bin
@@ -23,7 +23,7 @@ hm_create() {
 
 # Function to create the hash value (checksum)
 hm_hash() {
-	echo "$1" | md5sum -
+	echo "$1" | md5sum | head -c 32
 }
 
 # Argument 1: Hash Table


### PR DESCRIPTION
The output from md5sum contains extra characters after the hash. These are then used in the  filename in /tmp/
```
#  echo "phy1-ap0" | md5sum
8d7abf85ca96343a21d7bee774811085  -
```
```
# ls -lah /tmp/tmp.HfNMDd/8d7abf85ca96343a21d7bee774811085\ \ - 
-rw-r--r--    1 root     root          10 May 23 20:37 /tmp/tmp.HfNMDd/8d7abf85ca96343a21d7bee774811085  -
```

Use `head` to only get the 32 characters of the hash.