### PR TITLE
Increase startup sleep to avoid a possible race condition

### DIFF
--- a/initscript
+++ b/initscript
@@ -45,7 +45,7 @@ start_service() {
 }
 
 boot() {
-	sleep 30
+	sleep 120
 	start
 }
 


### PR DESCRIPTION
After system boot, with `sleep 30`, there seems to be some kind of a race condition. `bin` script fails to save any hashes to its tmp dir. Also it sets (all local SSIDs) - (current SSID) as neighbors for the current SSID, which is incorrect. This continues even when umdns receives a correct list of SSIDs in the other APs. It can be only fixed by service restart.

There's a "File not found" error logged to syslog during startup. Probably somehow related to the tmp dir. PROCD_DEBUG=1 doesn't reveal any detailed error messages. 

Increasing sleep to 120 seems to fix this problem. It doesn't seem to be a big deal to wait this much after a reboot.